### PR TITLE
FEAT:kakao_login_api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.13.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
@@ -46,6 +47,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -53,6 +59,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -182,6 +198,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -256,6 +283,14 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -347,6 +382,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -432,6 +481,59 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -562,6 +664,20 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -986,6 +1102,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev": "nodemon --exec node src/index.js"
   },
   "dependencies": {
+    "axios": "^1.13.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,0 +1,39 @@
+import { buildKakaoLoginURL, getKakaoToken, getKakaoUserInfo, loginWithKakao } from "../services/auth.service.js";
+import { LoginRequiredError } from "../errors.js";
+
+export const kakaoLoginRedirect = (req, res) => {
+    const kakaoURL = buildKakaoLoginURL(); //로그인 화면 URL
+    return res.redirect(kakaoURL); //로그인 화면으로 redirect
+};
+
+export const kakaoCallback = async (req, res) => {
+    try {
+        const { code } = req.query;//URL에서 쿼리 파라미터 추출. 프론트 있으면 req.body로 변경 필요
+
+        const accessToken = await getKakaoToken(code); //URL code를 통해 token 가져오기
+        const kakaoUser = await getKakaoUserInfo(accessToken); //토큰으로 유저 정보 가져오기
+        const user = await loginWithKakao(kakaoUser); //유저 정보 DB에 저장 후 user객체 반환
+
+        return res.success({
+            message: "카카오 로그인 성공",
+            kakaoUser
+        });
+
+    } catch (err) {
+        if (err instanceof LoginRequiredError) {
+        return res.error({
+            status: 401,
+            errorCode: err.errorCode,
+            reason: err.reason,
+            data: err.data,
+        });
+        }
+
+        //일반 에러
+        return res.error({
+        status: 500,
+        errorCode: "SERVER_ERROR",
+        reason: err.message,
+        });
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 import express from 'express';
+//import { pool } from "../db.config.js"
+import dotenv from "dotenv";
+import authRoutes from "./routers/auth.router.js";
 
 const app = express();
 const port = 3000;
+
+dotenv.config();
 
 // 요청 로깅
 app.use((req, res, next) => {
@@ -38,6 +43,9 @@ app.use(express.urlencoded({ extended: false }));
 app.get('/', (req, res) => {
   res.send('Hello World!');
 });
+
+//auth 경로 라우트
+app.use("/auth", authRoutes);
 
 // 서버 시작
 app.listen(port, () => {

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -1,0 +1,19 @@
+import { pool } from "../db.config.js";
+
+export const userRepository = { //유저 조회
+    findByProviderId: async (provider, kakao_id) => {
+        const [rows] = await pool.query(
+        "SELECT * FROM user WHERE provider = ? AND kakao_id = ?",
+        [provider, kakao_id]
+        );
+        return rows[0] || null;
+    },
+
+    createUser: async (provider, kakao_id, email, nickname) => { //유저 생성
+        const [result] = await pool.query(
+        "INSERT INTO user(provider, kakao_id, email, nickname) VALUES (?, ?, ?, ?)",
+        [provider, kakao_id, email, nickname]
+        );
+        return result.insertId;
+    }
+};

--- a/src/routers/auth.router.js
+++ b/src/routers/auth.router.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { kakaoLoginRedirect, kakaoCallback } from "../controllers/auth.controller.js";
+
+const router = express.Router();
+
+router.get("/kakao/login", kakaoLoginRedirect);
+router.get("/kakao/callback", kakaoCallback); //카카오->백엔드로 받아서 작성함(프론트 없어서)
+//router.post("/kakao/callback", kakaoCallback); //프론트 있을 때 사용
+
+export default router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -1,0 +1,90 @@
+import axios from "axios";
+import { LoginRequiredError } from "../errors.js";
+import { userRepository } from "../repositories/user.repository.js";
+
+//카카오 로그인 화면 띄우는 URL
+export const buildKakaoLoginURL = () => {
+    return (
+        `https://kauth.kakao.com/oauth/authorize?` +
+        `client_id=${process.env.KAKAO_REST_API_KEY}` + //앱 식별하는 API_KEY
+        `&redirect_uri=${process.env.KAKAO_REDIRECT_URI}` + //code 받는 URI
+        `&response_type=code` //카카오 서버가 주는 임시인증 code
+    );
+};
+
+//토큰 발급
+export const getKakaoToken = async (code) => {
+    try {
+        const url = "https://kauth.kakao.com/oauth/token"; //카카오에게 토큰 요청하는 서버 주소
+
+        const data = new URLSearchParams({
+        grant_type: "authorization_code", //Oauth 방식 인증
+        client_id: process.env.KAKAO_REST_API_KEY,
+        redirect_uri: process.env.KAKAO_REDIRECT_URI,
+        code,
+        });
+
+        //카카오 서버에 post 요청 전송
+        const res = await axios.post(url, data, {
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        });
+
+        return res.data.access_token; //post응답으로 카카오 서버가 토큰 반환(JSON)
+    } catch (err) {
+        console.error("KAKAO TOKEN ERROR", err.response?.data || err.message);
+
+    throw new LoginRequiredError(
+        "카카오 access_token 발급 실패",
+        err.response?.data
+        );
+    }  
+};
+
+//받은 토큰으로 유저 정보 조회
+export const getKakaoUserInfo = async (access_token) => {
+    try {
+        const res = await axios.get("https://kapi.kakao.com/v2/user/me", { //토큰으로 카카오 서버에 유저 정보 조회 get 요청
+        headers: {
+            Authorization: `Bearer ${access_token}`,
+        },
+        });
+
+        return res.data;//카카오 서버의 유저 정보 응답(id, email, nickname...)
+    } catch (err) {
+        console.error("KAKAO USER INFO ERROR", err.response?.data || err.message);
+
+        throw new LoginRequiredError(
+        "카카오 사용자 정보 조회 실패",
+        err.response?.data
+        );
+    }
+};
+
+
+export const loginWithKakao = async (kakaoUser) => { //카카오 API에서 받아온 사용자 정보(JSON)
+    const provider = "kakao";
+    const kakao_id = String(kakaoUser.id); //id
+    const email = kakaoUser.kakao_account?.email || null; //이메일
+    const nickname = kakaoUser.kakao_account?.profile?.nickname || `kakao_user_${kakaoUser.id}`; //NULL 값일 때 에러 발생
+
+    let user = await userRepository.findByProviderId(provider, kakao_id);
+
+    if (!user) { //기존 user 아니면 DB에 추가
+        const newId = await userRepository.createUser(
+        provider,
+        kakao_id,
+        email,
+        nickname
+        );
+
+        user = {
+        id: newId,
+        provider,
+        kakao_id,
+        email,
+        nickname
+        };
+    }
+
+    return user; //DB에서 찾은 사용자 객체 전달
+};


### PR DESCRIPTION
## 🔀 카카오 로그인 API + 유저 DB 저장

## 📌 개요
- 카카오 로그인 동의 화면
- 카카오 서버가 주는 임시인증 code로 토큰 발급
- 발급된 토큰으로 유저 정보 조회
- 신규 유저이면 DB에 정보 저장

## ✨ 작업 내용
- [✓] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
<카카오 Developer 기본 설정>
1. kakao Developer 앱 추가(아이콘 사진 입력 필수 : 개인 개발자 비즈 앱 전환을 위해서)
2. 개인 개발자 비즈 앱 전환
3. 앱 > 제품설정 > 카카오 로그인 > 동의항목에서 닉네임, email 필수 동의
4. Web 사이트 도메인 : http://localhost:3000
5. Redirect URI : http://localhost:3000/auth/kakao/callback
---
<테스트>
1. http://localhost:3000/auth/kakao/login 입력
2. DB에서 유저 정보 확인

## 📎 관련 이슈
- 

---

## ✔ 체크리스트
- [✓] 코드 컨벤션 지켰는가?
- [✓] 기존 기능이 깨지지 않는가?
- [✓] 테스트를 수행했는가?
- [✓] 리뷰어가 보기 편하게 PR을 나누었는가?

