### PR TITLE
[FEAT] 히스토리 저장 API 구현

### DIFF
--- a/src/controllers/history.controller.js
+++ b/src/controllers/history.controller.js
@@ -1,0 +1,33 @@
+import { createHistory } from "../services/history.service.js";
+
+export const saveMyHistory = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { coachingId } = req.body;
+
+    if (!coachingId) {
+      return res.error({
+        status: 400,
+        errorCode: "INVALID_INPUT",
+        reason: "coachingId는 필수입니다."
+      });
+    }
+
+    const historyData = await createHistory(userId, coachingId);
+
+    return res.success({
+      message: "히스토리에 성공적으로 저장되었습니다.",
+      data: historyData
+    });
+
+  } catch (error) {
+    console.error("히스토리 저장 오류:", error);
+
+    return res.error({
+      status: error.statusCode || 500,
+      errorCode: error.errorCode || "SERVER_ERROR",
+      reason: error.reason || error.message || "서버 오류",
+      data: error.data || null
+    });
+  }
+};

--- a/src/errors.js
+++ b/src/errors.js
@@ -6,3 +6,23 @@ export class LoginRequiredError extends Error {
     this.data = data;
   }
 }
+
+export class BadRequestError extends Error {
+  errorCode = "HISTORY_ALREADY_EXISTS";
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}
+
+export class ForbiddenError extends Error {
+  statusCode = 403;
+  errorCode = "FORBIDDEN";
+
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import reviewRouter from "./routers/review.route.js";
 import likeRouter from "./routers/like.route.js";
 import authRoutes from "./routers/auth.route.js";
 import userRouter from "./routers/user.route.js"
+import historyRouter from "./routers/history.route.js";
 
 //import { redisClient } from "./config/redis.config.js";
 
@@ -58,6 +59,7 @@ app.use("/reviews", likeRouter);
 
 app.use("/auth", authRoutes); //auth 경로 라우트
 app.use("/user", userRouter); //user 경로 라우트
+app.use("/history", historyRouter);
 
 // 서버 시작
 app.listen(port, () => {

--- a/src/repositories/history.repository.js
+++ b/src/repositories/history.repository.js
@@ -1,0 +1,38 @@
+import { pool } from "../db.config.js";
+
+// 중복 확인
+export const checkHistoryExists = async (userId, coachingId) => {
+    const sql = `
+        SELECT id
+        FROM history
+        WHERE user_id = ? AND coaching_id = ?
+        LIMIT 1;
+    `;
+
+    const [rows] = await pool.query(sql, [userId, coachingId]);
+    return rows.length > 0; 
+};
+
+// 코칭 세션이 해당 사용자의 것인지 확인
+export const checkCoachingSessionOwner = async (coachingId, userId) => {
+  const sql = `
+    SELECT id 
+    FROM coaching_session
+    WHERE id = ? AND user_id = ?
+    LIMIT 1;
+  `;
+
+  const [rows] = await pool.query(sql, [coachingId, userId]);
+  return rows.length > 0; 
+};
+
+// 히스토리 저장
+export const saveHistory = async (userId, coachingId) => {
+  const sql = `
+      INSERT INTO history (user_id, coaching_id)
+      VALUES (?, ?);
+  `;
+
+  const [result] = await pool.query(sql, [userId, coachingId]);
+  return result.insertId;  
+};

--- a/src/routers/history.route.js
+++ b/src/routers/history.route.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { saveMyHistory } from "../controllers/history.controller.js";
+import { authRequired } from "../middlewares/auth.middleware.js";
+import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
+
+const router = express.Router();
+
+router.post("/", verifyServiceAccessJWT, authRequired, saveMyHistory);
+
+export default router;

--- a/src/services/history.service.js
+++ b/src/services/history.service.js
@@ -1,0 +1,30 @@
+import { checkHistoryExists, saveHistory, checkCoachingSessionOwner } from "../repositories/history.repository.js";
+import { BadRequestError, ForbiddenError } from "../errors.js";
+
+export const createHistory = async (userId, coachingId) => {
+
+  // 내 코칭 세션인지 확인
+  const isOwner = await checkCoachingSessionOwner(coachingId, userId);
+  if (!isOwner) {
+    throw new ForbiddenError("본인의 코칭 세션만 히스토리에 저장할 수 있습니다.", {
+      coachingId
+    });
+  }
+
+  // 중복 체크
+  const exists = await checkHistoryExists(userId, coachingId);
+  if (exists) {
+    throw new BadRequestError("이미 저장된 코칭 세션입니다.", {
+      coachingId
+    });
+  }
+
+  // 저장
+  const historyId = await saveHistory(userId, coachingId);
+
+  return {
+    user_id: userId,
+    coaching_id: coachingId,
+    history_id: historyId
+  };
+};


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->
[FEAT] 히스토리 저장 API 구현

---

## 📌 개요
- 사용자가 코칭받은 세션을 히스토리에 저장할 수 있도록 하는 기능을 추가
- 복 저장 방지와 본인 세션 검증 로직을 포함하여 안정적으로 저장되도록 구현

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1. 로그인 후 코칭 세션을 생성
2. 생성된 coachingId를 사용하여 /history 로 POST 요청을 보낸다.
- Body: { "coachingId": <id> }
3. 히스토리에 정상 저장되는지 확인

---

## 📎 관련 이슈
- Close #21 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

