### PR TITLE
[FEAT] 히스토리 조회 API 구현

### DIFF
--- a/src/controllers/history.controller.js
+++ b/src/controllers/history.controller.js
@@ -1,4 +1,6 @@
-import { createHistory } from "../services/history.service.js";
+import {
+     createHistory, fetchUserHistoryList, fetchHistoryDetail
+} from "../services/history.service.js";
 
 export const saveMyHistory = async (req, res) => {
   try {
@@ -27,6 +29,50 @@ export const saveMyHistory = async (req, res) => {
       status: error.statusCode || 500,
       errorCode: error.errorCode || "SERVER_ERROR",
       reason: error.reason || error.message || "서버 오류",
+      data: error.data || null
+    });
+  }
+};
+
+export const getMyHistoryList = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const list = await fetchUserHistoryList(userId);
+
+    return res.success({
+      message: "히스토리 목록 조회 성공",
+      data: list
+    });
+
+  } catch (error) {
+    console.error("히스토리 목록 조회 오류:", error);
+    return res.error({
+      status: error.statusCode || 500,
+      errorCode: error.errorCode || "SERVER_ERROR",
+      reason: error.reason || error.message,
+      data: error.data || null
+    });
+  }
+};
+
+export const getMyHistoryDetail = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const historyId = req.params.id;
+
+    const detail = await fetchHistoryDetail(userId, historyId);
+
+    return res.success({
+      message: "히스토리 상세 조회 성공",
+      data: detail
+    });
+
+  } catch (error) {
+    console.error("히스토리 상세 조회 오류:", error);
+    return res.error({
+      status: error.statusCode || 500,
+      errorCode: error.errorCode || "SERVER_ERROR",
+      reason: error.reason || error.message,
       data: error.data || null
     });
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,26 +1,45 @@
+// 로그인 필요 에러 (401)
 export class LoginRequiredError extends Error {
-  errorCode = "U001";
-  constructor(reason = "로그인이 필요합니다.", data) {
+  statusCode = 401;
+  errorCode = "LOGIN_REQUIRED";
+
+  constructor(reason = "로그인이 필요합니다.", data = null) {
     super(reason);
     this.reason = reason;
     this.data = data;
   }
 }
 
+// 잘못된 요청 (400) 
 export class BadRequestError extends Error {
+  statusCode = 400;
   errorCode = "HISTORY_ALREADY_EXISTS";
-  constructor(reason, data) {
+
+  constructor(reason = "잘못된 요청입니다.", data = null) {
     super(reason);
     this.reason = reason;
     this.data = data;
   }
 }
 
+// 권한 없음 (403)
 export class ForbiddenError extends Error {
   statusCode = 403;
   errorCode = "FORBIDDEN";
 
-  constructor(reason, data) {
+  constructor(reason = "접근 권한이 없습니다.", data = null) {
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}
+
+// 조회 실패 (404)
+export class NotFoundError extends Error {
+  statusCode = 404;
+  errorCode = "NOT_FOUND";
+
+  constructor(reason = "요청한 리소스를 찾을 수 없습니다.", data = null) {
     super(reason);
     this.reason = reason;
     this.data = data;

--- a/src/repositories/history.repository.js
+++ b/src/repositories/history.repository.js
@@ -36,3 +36,39 @@ export const saveHistory = async (userId, coachingId) => {
   const [result] = await pool.query(sql, [userId, coachingId]);
   return result.insertId;  
 };
+
+// 최신순 히스토리 목록 조회
+export const getUserHistoryList = async (userId) => {
+  const sql = `
+    SELECT
+      h.id AS history_id, h.coaching_id, h.created_at,
+      cs.job_category_id, q.content AS question_content,
+      cs.answer_text, cs.ai_feedback
+    FROM history h
+    JOIN coaching_session cs ON h.coaching_id = cs.id
+    JOIN question q ON cs.question_id = q.id
+    WHERE h.user_id = ?
+    ORDER BY h.created_at DESC;
+  `;
+
+  const [rows] = await pool.query(sql, [userId]);
+  return rows;
+};
+
+// 히스토리 상세 조회
+export const getHistoryDetail = async (userId, historyId) => {
+  const sql = `
+    SELECT
+      h.id AS history_id, h.coaching_id, h.created_at,
+      cs.job_category_id, cs.question_id, q.content AS question_content,
+      cs.answer_text, cs.ai_feedback, cs.ai_model_answer
+    FROM history h
+    JOIN coaching_session cs ON h.coaching_id = cs.id
+    JOIN question q ON cs.question_id = q.id
+    WHERE h.user_id = ? AND h.id = ?
+    LIMIT 1;
+  `;
+
+  const [rows] = await pool.query(sql, [userId, historyId]);
+  return rows[0];
+};

--- a/src/routers/history.route.js
+++ b/src/routers/history.route.js
@@ -1,10 +1,21 @@
 import express from "express";
-import { saveMyHistory } from "../controllers/history.controller.js";
+import { saveMyHistory, getMyHistoryList, getMyHistoryDetail } from "../controllers/history.controller.js";
 import { authRequired } from "../middlewares/auth.middleware.js";
 import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
 
 const router = express.Router();
 
+// 히스토리에 저장
 router.post("/", verifyServiceAccessJWT, authRequired, saveMyHistory);
 
+// 최신순 히스토리 목록 조회
+router.get("/", verifyServiceAccessJWT, authRequired, getMyHistoryList);
+
+// 히스토리 상세 조회
+router.get("/:id", verifyServiceAccessJWT, authRequired, getMyHistoryDetail);
+
 export default router;
+
+
+
+

--- a/src/services/history.service.js
+++ b/src/services/history.service.js
@@ -1,5 +1,8 @@
-import { checkHistoryExists, saveHistory, checkCoachingSessionOwner } from "../repositories/history.repository.js";
-import { BadRequestError, ForbiddenError } from "../errors.js";
+import { 
+    checkHistoryExists, saveHistory, checkCoachingSessionOwner,
+    getUserHistoryList, getHistoryDetail
+} from "../repositories/history.repository.js";
+import { BadRequestError, ForbiddenError,NotFoundError } from "../errors.js";
 
 export const createHistory = async (userId, coachingId) => {
 
@@ -27,4 +30,18 @@ export const createHistory = async (userId, coachingId) => {
     coaching_id: coachingId,
     history_id: historyId
   };
+};
+
+export const fetchUserHistoryList = async (userId) => {
+  return await getUserHistoryList(userId);
+};
+
+export const fetchHistoryDetail = async (userId, historyId) => {
+  const detail = await getHistoryDetail(userId, historyId);
+
+  if (!detail) {
+    throw new NotFoundError("해당 히스토리를 찾을 수 없습니다.", { historyId });
+  }
+
+  return detail;
 };


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->

---

## 📌 개요
- 로그인한 사용자의 코칭 히스토리를 조회할 수 있는 기능을 추가
- 히스토리 목록 조회 API (GET /history) 구현
- 히스토리 상세 조회 API (GET /history/:id) 구현
- 본인 소유 히스토리만 조회 가능하도록 처리

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1. 로그인 후 Authorization 헤더에 Access Token을 포함하여 요청
2. GET /history 호출 → 본인 히스토리 목록이 최신순으로 반환되는지 확인
3. GET /history/{id} 호출 → 상세 내용(질문/답변/AI 피드백 등) 확인

---

## 📎 관련 이슈
- Close #22 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

