### PR TITLE
[FEAT] 히스토리 삭제 API 삭제

### DIFF
--- a/src/controllers/history.controller.js
+++ b/src/controllers/history.controller.js
@@ -1,79 +1,75 @@
 import {
-     createHistory, fetchUserHistoryList, fetchHistoryDetail
+  createHistory,
+  fetchUserHistoryList, fetchHistoryDetail,
+  removeHistory, removeAllHistory
 } from "../services/history.service.js";
+import { BadRequestError } from "../errors.js";
 
-export const saveMyHistory = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    const { coachingId } = req.body;
+// 히스토리 저장
+export const saveMyHistory = async (req, res, next) => {
+  const userId = req.user.id;
+  const { coachingId } = req.body;
 
-    if (!coachingId) {
-      return res.error({
-        status: 400,
-        errorCode: "INVALID_INPUT",
-        reason: "coachingId는 필수입니다."
-      });
-    }
-
-    const historyData = await createHistory(userId, coachingId);
-
-    return res.success({
-      message: "히스토리에 성공적으로 저장되었습니다.",
-      data: historyData
-    });
-
-  } catch (error) {
-    console.error("히스토리 저장 오류:", error);
-
-    return res.error({
-      status: error.statusCode || 500,
-      errorCode: error.errorCode || "SERVER_ERROR",
-      reason: error.reason || error.message || "서버 오류",
-      data: error.data || null
-    });
+  if (!coachingId) {
+    throw new BadRequestError("coachingId는 필수입니다.");
   }
+
+  const historyData = await createHistory(userId, coachingId);
+
+  return res.success({
+    message: "히스토리에 성공적으로 저장되었습니다.",
+    data: historyData,
+  });
 };
 
-export const getMyHistoryList = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    const list = await fetchUserHistoryList(userId);
+// 히스토리 목록 조회
+export const getMyHistoryList = async (req, res, next) => {
+  const userId = req.user.id;
+  const list = await fetchUserHistoryList(userId);
 
-    return res.success({
-      message: "히스토리 목록 조회 성공",
-      data: list
-    });
-
-  } catch (error) {
-    console.error("히스토리 목록 조회 오류:", error);
-    return res.error({
-      status: error.statusCode || 500,
-      errorCode: error.errorCode || "SERVER_ERROR",
-      reason: error.reason || error.message,
-      data: error.data || null
-    });
-  }
+  return res.success({
+    message:
+      list.length === 0
+        ? "저장된 히스토리가 없습니다."
+        : "히스토리 목록 조회 성공",
+    data: list,
+  });
 };
 
-export const getMyHistoryDetail = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    const historyId = req.params.id;
+// 히스토리 상세 조회
+export const getMyHistoryDetail = async (req, res, next) => {
+  const userId = req.user.id;
+  const historyId = req.params.id;
 
-    const detail = await fetchHistoryDetail(userId, historyId);
+  const detail = await fetchHistoryDetail(userId, historyId);
 
-    return res.success({
-      message: "히스토리 상세 조회 성공",
-      data: detail
-    });
+  return res.success({
+    message: "히스토리 상세 조회 성공",
+    data: detail,
+  });
+};
 
-  } catch (error) {
-    console.error("히스토리 상세 조회 오류:", error);
-    return res.error({
-      status: error.statusCode || 500,
-      errorCode: error.errorCode || "SERVER_ERROR",
-      reason: error.reason || error.message,
-      data: error.data || null
-    });
-  }
+// 히스토리 개별 삭제
+export const deleteMyHistory = async (req, res, next) => {
+  const userId = req.user.id;
+  const { id } = req.params;
+
+  const result = await removeHistory(userId, id);
+
+  return res.success({
+    message: "히스토리가 성공적으로 삭제되었습니다.",
+    data: result,
+  });
+};
+
+// 히스토리 전체 삭제
+export const deleteAllMyHistory = async (req, res, next) => {
+  const userId = req.user.id;
+
+  const result = await removeAllHistory(userId);
+
+  return res.success({
+    message: "히스토리를 모두 삭제했습니다.",
+    data: result,
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,19 @@ app.use("/auth", authRoutes); //auth 경로 라우트
 app.use("/user", userRouter); //user 경로 라우트
 app.use("/history", historyRouter);
 
+
+// 전역 에러 핸들러
+app.use((err, req, res, next) => {
+  console.error("GLOBAL ERROR:", err);
+
+  return res.error({
+    status: err.statusCode || 500,
+    errorCode: err.errorCode || "SERVER_ERROR",
+    reason: err.reason || err.message || "서버 오류",
+    data: err.data || null
+  });
+});
+
 // 서버 시작
 app.listen(port, () => {
   console.log(`Server running on port ${port}`);

--- a/src/repositories/history.repository.js
+++ b/src/repositories/history.repository.js
@@ -2,12 +2,7 @@ import { pool } from "../db.config.js";
 
 // 중복 확인
 export const checkHistoryExists = async (userId, coachingId) => {
-    const sql = `
-        SELECT id
-        FROM history
-        WHERE user_id = ? AND coaching_id = ?
-        LIMIT 1;
-    `;
+    const sql = `SELECT id FROM history WHERE user_id = ? AND coaching_id = ? LIMIT 1;`;
 
     const [rows] = await pool.query(sql, [userId, coachingId]);
     return rows.length > 0; 
@@ -15,12 +10,7 @@ export const checkHistoryExists = async (userId, coachingId) => {
 
 // 코칭 세션이 해당 사용자의 것인지 확인
 export const checkCoachingSessionOwner = async (coachingId, userId) => {
-  const sql = `
-    SELECT id 
-    FROM coaching_session
-    WHERE id = ? AND user_id = ?
-    LIMIT 1;
-  `;
+  const sql = `SELECT id FROM coaching_session WHERE id = ? AND user_id = ? LIMIT 1;`;
 
   const [rows] = await pool.query(sql, [coachingId, userId]);
   return rows.length > 0; 
@@ -28,10 +18,7 @@ export const checkCoachingSessionOwner = async (coachingId, userId) => {
 
 // 히스토리 저장
 export const saveHistory = async (userId, coachingId) => {
-  const sql = `
-      INSERT INTO history (user_id, coaching_id)
-      VALUES (?, ?);
-  `;
+  const sql = `INSERT INTO history (user_id, coaching_id) VALUES (?, ?);`;
 
   const [result] = await pool.query(sql, [userId, coachingId]);
   return result.insertId;  
@@ -71,4 +58,34 @@ export const getHistoryDetail = async (userId, historyId) => {
 
   const [rows] = await pool.query(sql, [userId, historyId]);
   return rows[0];
+};
+
+// 히스토리 단건 존재 여부 확인
+export const checkHistoryIdExists = async (historyId) => {
+  const sql = `SELECT id FROM history WHERE id = ? LIMIT 1;`;
+  const [rows] = await pool.query(sql, [historyId]);
+  return rows.length > 0;
+};
+
+// 히스토리 소유자 확인
+export const checkHistoryOwner = async (historyId, userId) => {
+  const sql = `SELECT id FROM history WHERE id = ? AND user_id = ? LIMIT 1;`;
+  const [rows] = await pool.query(sql, [historyId, userId]);
+  return rows.length > 0;
+};
+
+// 히스토리 삭제
+export const deleteHistoryById = async (historyId) => {
+  const sql = ` DELETE FROM history WHERE id = ?;`;
+
+  const [result] = await pool.query(sql, [historyId]);
+  return result.affectedRows > 0;  // true면 삭제 성공
+};
+
+// 전체 히스토리 삭제 (특정 사용자)
+export const deleteAllHistoryByUserId = async (userId) => {
+  const sql = `DELETE FROM history WHERE user_id = ?;`;
+
+  const [result] = await pool.query(sql, [userId]);
+  return result.affectedRows; // 삭제된 row 수
 };

--- a/src/routers/history.route.js
+++ b/src/routers/history.route.js
@@ -1,5 +1,8 @@
 import express from "express";
-import { saveMyHistory, getMyHistoryList, getMyHistoryDetail } from "../controllers/history.controller.js";
+import { 
+    saveMyHistory, getMyHistoryList, getMyHistoryDetail,
+    deleteMyHistory, deleteAllMyHistory
+ } from "../controllers/history.controller.js";
 import { authRequired } from "../middlewares/auth.middleware.js";
 import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
 
@@ -13,6 +16,12 @@ router.get("/", verifyServiceAccessJWT, authRequired, getMyHistoryList);
 
 // 히스토리 상세 조회
 router.get("/:id", verifyServiceAccessJWT, authRequired, getMyHistoryDetail);
+
+// 히스토리 전체 삭제
+router.delete("/all", verifyServiceAccessJWT, authRequired, deleteAllMyHistory);
+
+// 히스토리 개별 삭제
+router.delete("/:id", verifyServiceAccessJWT, authRequired, deleteMyHistory);
 
 export default router;
 

--- a/src/services/history.service.js
+++ b/src/services/history.service.js
@@ -1,6 +1,7 @@
 import { 
     checkHistoryExists, saveHistory, checkCoachingSessionOwner,
-    getUserHistoryList, getHistoryDetail
+    getUserHistoryList, getHistoryDetail,
+    checkHistoryIdExists, checkHistoryOwner, deleteHistoryById, deleteAllHistoryByUserId
 } from "../repositories/history.repository.js";
 import { BadRequestError, ForbiddenError,NotFoundError } from "../errors.js";
 
@@ -44,4 +45,33 @@ export const fetchHistoryDetail = async (userId, historyId) => {
   }
 
   return detail;
+};
+
+// 히스토리에서 개별 삭제
+export const removeHistory = async (userId, historyId) => {
+  // 히스토리 존재 여부
+  const exists = await checkHistoryIdExists(historyId);
+  if (!exists) {
+    throw new NotFoundError("해당 히스토리를 찾을 수 없습니다.", { historyId });
+  }
+
+  // 소유자 확인
+  const isOwner = await checkHistoryOwner(historyId, userId);
+  if (!isOwner) {
+    throw new ForbiddenError("해당 히스토리를 삭제할 권한이 없습니다.", { historyId });
+  }
+
+  // 삭제
+  await deleteHistoryById(historyId);
+
+  return { deleted: true, historyId };
+};
+
+export const removeAllHistory = async (userId) => {
+  const deletedCount = await deleteAllHistoryByUserId(userId);
+
+  return {
+    deleted: true,
+    deletedCount
+  };
 };


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->

---

## 📌 개요
- 사용자가 저장해둔 코칭 히스토리를 개별 또는 전체 단위로 삭제할 수 있도록 기능을 추가
- 본인 소유 히스토리만 삭제 가능하도록 검증 로직을 포함

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1. Access Token 포함하여 요청하기
2. 개별 삭제 테스트
- DELETE /history/:id
- 본인 히스토리 → 삭제 성공
3. 전체 삭제 테스트
- DELETE /history/all
- 삭제된 row 수(deletedCount)가 정상적으로 반환되는지 확인

---

## 📎 관련 이슈
- Close #23 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

