### PR TITLE
[FEAT] 관리자 로그인·권한 시스템 추가 및 면접 후/좋아요 기능 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.13.2",
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
@@ -84,6 +85,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1097,6 +1112,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "axios": "^1.13.2",
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",

--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -1,0 +1,17 @@
+import { adminLogin } from "../services/admin.service.js";
+
+export const adminLoginController = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    const result = await adminLogin(email, password);
+
+    return res.success(result);
+  } catch (err) {
+    return res.error({
+      status: 401,
+      errorCode: "ADMIN_LOGIN_FAILED",
+      reason: err.message
+    });
+  }
+};

--- a/src/controllers/like.controller.js
+++ b/src/controllers/like.controller.js
@@ -2,6 +2,14 @@ import { toggleReviewLike } from "../services/like.service.js";
 
 export const toggleReviewLikeController = async (req, res) => {
   try {
+    if (req.isAdmin) {
+      return res.error({
+        status: 403,
+        errorCode: "ADMIN_CANNOT_LIKE",
+        reason: "관리자는 좋아요 기능을 사용할 수 없습니다."
+      });
+    }
+    
     const userId = req.user.id;         
     const reviewId = req.params.reviewId;
 

--- a/src/controllers/review.controller.js
+++ b/src/controllers/review.controller.js
@@ -9,6 +9,14 @@ import {
 // 후기 생성
 export const createReviewController = async (req, res) => {
   try {
+    if (req.isAdmin) {
+      return res.error({
+        status: 403,
+        errorCode: "ADMIN_CANNOT_CREATE_REVIEW",
+        reason: "관리자는 후기를 작성할 수 없습니다."
+      });
+    }
+
     const review = await createReview(req.user.id, req.body);
     return res.success(review);
   } catch (err) {
@@ -25,7 +33,11 @@ export const createReviewController = async (req, res) => {
 // 후기 상세 조회
 export const getReviewController = async (req, res) => {
   try {
-    const review = await getReview(req.params.reviewId);
+    const review = await getReview(
+      req.params.reviewId,
+      req.isAdmin ? null : req.user?.id
+    );
+
     return res.success(review);
   } catch (err) {
     return res.error({
@@ -40,7 +52,7 @@ export const getReviewController = async (req, res) => {
 // 후기 수정
 export const updateReviewController = async (req, res) => {
   try {
-    const updated = await updateReview(req.user.id, req.params.reviewId, req.body);
+    const updated = await updateReview(req.user.id, req.params.reviewId, req.body, req.isAdmin, req.isAdmin ? req.user.id : null);
     return res.success(updated);
   } catch (err) {
     console.error(err);
@@ -56,7 +68,7 @@ export const updateReviewController = async (req, res) => {
 // 후기 삭제
 export const deleteReviewController = async (req, res) => {
   try {
-    const result = await deleteReview(req.user.id, req.params.reviewId);
+    const result = await deleteReview(req.user.id, req.params.reviewId, req.isAdmin);
     return res.success(result);
   } catch (err) {
     console.error(err);
@@ -72,8 +84,9 @@ export const deleteReviewController = async (req, res) => {
 // 후기 목록 조회 (로그인 여부 optional)
 export const getReviewListController = async (req, res) => {
   try {
-    const userId = req.user ? req.user.id : null; 
+    const userId = req.user && !req.isAdmin ? req.user.id : null;
     const list = await getReviewList(req.query, userId);
+
 
     return res.success(list);
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import likeRouter from "./routers/like.route.js";
 import authRoutes from "./routers/auth.route.js";
 import userRouter from "./routers/user.route.js"
 import historyRouter from "./routers/history.route.js";
+import adminRoutes from "./routers/admin.route.js";
 
 //import { redisClient } from "./config/redis.config.js";
 
@@ -60,6 +61,7 @@ app.use("/reviews", likeRouter);
 app.use("/auth", authRoutes); //auth 경로 라우트
 app.use("/user", userRouter); //user 경로 라우트
 app.use("/history", historyRouter);
+app.use("/admin", adminRoutes);
 
 
 // 전역 에러 핸들러
@@ -78,3 +80,6 @@ app.use((err, req, res, next) => {
 app.listen(port, () => {
   console.log(`Server running on port ${port}`);
 });
+
+
+

--- a/src/middlewares/jwt.middleware.js
+++ b/src/middlewares/jwt.middleware.js
@@ -16,7 +16,11 @@ export const verifyServiceAccessJWT = (req, res, next) => {
         return res.error({ status: 401, errorCode: "INVALID_TOKEN_TYPE", reason: "Not an access token" });
         }
         
-        req.user = { id: decoded.id }; //다음 라우트에서 req.user.id 정보 사용 가능
+        req.user = { 
+            id: decoded.id,
+            role: decoded.role || "user"   // 기본값 user
+        };
+        
         next();
     } catch (err) {
         return res.error({ status: 401, errorCode: "INVALID_OR_EXPIRED", reason: err.message });

--- a/src/middlewares/role.middleware.js
+++ b/src/middlewares/role.middleware.js
@@ -1,0 +1,7 @@
+// 관리자 여부를 JWT payload의 role 값으로 판단하는 미들웨어
+
+export const setUserRole = (req, res, next) => {
+  // verifyServiceAccessJWT 후에 실행되어야 req.user가 존재함
+  req.isAdmin = req.user?.role === "admin";
+  next();
+};

--- a/src/repositories/admin.repository.js
+++ b/src/repositories/admin.repository.js
@@ -1,0 +1,7 @@
+import { pool } from "../db.config.js";
+
+export const findAdminByEmail = async (email) => {
+  const sql = `SELECT * FROM admin WHERE email = ? LIMIT 1`;
+  const [rows] = await pool.query(sql, [email]);
+  return rows[0];
+};

--- a/src/repositories/review.repository.js
+++ b/src/repositories/review.repository.js
@@ -22,28 +22,47 @@ export const getReviewRepo = async (id, userId = null) => {
       r.*,
       u.nickname,
       j.name AS job_category_name,
+
+      -- 좋아요 여부
       EXISTS (
         SELECT 1 FROM review_likes 
         WHERE review_id = r.id AND user_id = ?
-      ) AS liked
+      ) AS liked,
+
+      -- 관리자 수정 여부 (0 = 사용자 수정, 1 = 관리자 수정)
+      CASE 
+        WHEN r.edited_by_admin_id IS NOT NULL THEN 1
+        ELSE 0
+      END AS edited_by_admin,
+
+      -- 관리자 이름(관리자가 수정한 경우)
+      a.name AS edited_admin_name
+
     FROM review r
     JOIN user u ON r.user_id = u.id
     JOIN job_category j ON r.job_category_id = j.id
+
+    -- 관리자 테이블 LEFT JOIN (수정 안 했을 수 있으므로 LEFT JOIN)
+    LEFT JOIN admin a ON r.edited_by_admin_id = a.id
+
     WHERE r.id = ?
   `;
 
-  const [rows] = await pool.query(sql, [userId || 0, id]); 
+  const [rows] = await pool.query(sql, [userId || 0, id]);
   return rows[0];
 };
 
-export const updateReviewRepo = async (id, data) => {
+
+export const updateReviewRepo = async (id, data, editedByAdminId = null) => {
   const sql = `
     UPDATE review
     SET 
       company_name = ?,
       job_category_id = ?,
       content = ?,
-      interview_tip = ?
+      interview_tip = ?,
+      edited_by_admin_id = ?,
+      updated_at = NOW()
     WHERE id = ?
   `;
 
@@ -52,9 +71,11 @@ export const updateReviewRepo = async (id, data) => {
     data.job_category_id,
     data.content,
     data.interview_tip || null,
+    editedByAdminId,
     id
   ]);
 };
+
 
 export const deleteReviewRepo = async (reviewId) => {
   const sql = `DELETE FROM review WHERE id = ?`;

--- a/src/routers/admin.route.js
+++ b/src/routers/admin.route.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { adminLoginController } from "../controllers/admin.controller.js";
+
+const router = express.Router();
+
+// 관리자 로그인
+router.post("/login", adminLoginController);
+
+export default router;

--- a/src/routers/like.route.js
+++ b/src/routers/like.route.js
@@ -2,10 +2,11 @@ import express from "express";
 import { toggleReviewLikeController } from "../controllers/like.controller.js";
 import { authRequired } from "../middlewares/auth.middleware.js";
 import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
+import { setUserRole } from "../middlewares/role.middleware.js";
 
 const router = express.Router();
 
 // 좋아요 기능
-router.patch("/:reviewId/like", verifyServiceAccessJWT, authRequired, toggleReviewLikeController);
+router.patch("/:reviewId/like", verifyServiceAccessJWT, authRequired, setUserRole, toggleReviewLikeController);
 
 export default router;

--- a/src/routers/review.route.js
+++ b/src/routers/review.route.js
@@ -8,13 +8,14 @@ import {
 } from "../controllers/review.controller.js";
 import { authRequired } from "../middlewares/auth.middleware.js";
 import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
+import { setUserRole } from "../middlewares/role.middleware.js";
 
 const router = express.Router();
 
 // 로그인 필요
-router.post("/", verifyServiceAccessJWT, authRequired, createReviewController);
-router.patch("/:reviewId", verifyServiceAccessJWT, authRequired, updateReviewController);
-router.delete("/:reviewId", verifyServiceAccessJWT, authRequired, deleteReviewController);
+router.post("/", verifyServiceAccessJWT, authRequired, setUserRole, createReviewController);
+router.patch("/:reviewId", verifyServiceAccessJWT, authRequired, setUserRole, updateReviewController);
+router.delete("/:reviewId", verifyServiceAccessJWT, authRequired, setUserRole, deleteReviewController);
 // 로그인 필요 X
 router.get("/:reviewId", getReviewController);      
 router.get("/", getReviewListController);

--- a/src/services/admin.service.js
+++ b/src/services/admin.service.js
@@ -1,0 +1,50 @@
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+import { redisClient } from "../config/redis.config.js";
+import { findAdminByEmail } from "../repositories/admin.repository.js";
+
+export const adminLogin = async (email, password) => {
+  const admin = await findAdminByEmail(email);
+  if (!admin) throw new Error("관리자를 찾을 수 없습니다.");
+
+  const isMatch = await bcrypt.compare(password, admin.password);
+  if (!isMatch) throw new Error("비밀번호가 일치하지 않습니다.");
+
+  // admin 전용 access token
+  const accessToken = jwt.sign(
+    {
+      id: admin.id,
+      email: admin.email,
+      role: "admin",
+      type: "access"
+    },
+    process.env.JWT_SECRET,
+    { expiresIn: "2h" }
+  );
+
+  // admin 전용 refresh token
+  const refreshToken = jwt.sign(
+    {
+      id: admin.id,
+      role: "admin",
+      type: "refresh"
+    },
+    process.env.JWT_SECRET,
+    { expiresIn: "14d" }
+  );
+
+  // Redis 저장 (refresh rotation)
+  await redisClient.set(`admin-refresh:${admin.id}`, refreshToken);
+
+  return {
+    admin: {
+      id: admin.id,
+      email: admin.email,
+      role: "admin"
+    },
+    tokens: {
+      accessToken,
+      refreshToken
+    }
+  };
+};

--- a/src/services/review.service.js
+++ b/src/services/review.service.js
@@ -22,22 +22,24 @@ export const getReview = async (reviewId) => {
   return review;
 };
 
-export const updateReview = async (user_id, reviewId, body) => {
+export const updateReview = async (user_id, reviewId, body, isAdmin, adminId) => {
   const existing = await getReviewRepo(reviewId);
   if (!existing) throw new Error("리뷰를 찾을 수 없습니다.");
-  if (existing.user_id !== user_id) throw new Error("본인이 작성한 후기만 수정할 수 있습니다.");
+  if (!isAdmin && existing.user_id !== user_id) throw new Error("본인이 작성한 후기만 수정할 수 있습니다.");
 
-  await updateReviewRepo(reviewId, body);
+  const editedByAdminId = isAdmin ? adminId : null;
+
+  await updateReviewRepo(reviewId, body, editedByAdminId);
   return await getReviewRepo(reviewId);
 };
 
-export const deleteReview = async (user_id, reviewId) => {
+export const deleteReview = async (user_id, reviewId, isAdmin) => {
   const existing = await getReviewRepo(reviewId);
   if (!existing) {
     throw new Error("리뷰를 찾을 수 없습니다.");
   }
 
-  if (existing.user_id !== user_id) {
+  if (!isAdmin && existing.user_id !== user_id) {
     throw new Error("본인이 작성한 후기만 삭제할 수 있습니다.");
   }
 


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->

---

## 📌 개요
- 관리자 전용 인증·인가 기능을 신규 추가하고, 해당 권한 체계를 리뷰/좋아요 기능 전체에 적용하기 위해 관련 컨트롤러, 서비스, 레포지토리, 라우터 구조를 리팩토링
- 관리자 로그인 API 구현 (email/password 기반)
- 관리자 전용 access/refresh token 발급 기능 추가
- Redis 기반 관리자 refresh token rotation 적용
- 관리자 전용 라우터(/admin) 추가
- setUserRole 미들웨어 구현 (req.isAdmin 설정)
- 리뷰 수정/삭제 시 관리자 권한 로직 적용
- edited_by_admin_id 컬럼을 이용한 관리자 수정 이력 반영
- 좋아요 기능에서 관리자 요청 차단 처리
- review/like route에 setUserRole 적용
- 기존 review.controller/service/repository 내부 로직 정리
- JWT 미들웨어에 role(admin/user) 기반 분기 추가

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [x] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1. 관리자 로그인 테스트
2. 관리자 토큰으로 후기 수정 테스트
3. 관리자 좋아요 요청 시 오류 반환 확인
4. 일반 사용자 계정으로 기존 기능 정상 동작 테스트

---

## 📎 관련 이슈
- Close #27 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

