### PR TITLE
[FEAT] 관리자 코칭 조회 기능 추가

### DIFF
--- a/src/controllers/adminCoaching.controller.js
+++ b/src/controllers/adminCoaching.controller.js
@@ -1,0 +1,25 @@
+import { getAllCoachingSessions } from "../services/adminCoaching.service.js";
+import { getCoachingSessionDetail } from "../services/adminCoaching.service.js";
+import { NotFoundError } from "../errors.js";
+
+export const getAdminCoachingList = async (req, res, next) => {
+  const list = await getAllCoachingSessions();
+  return res.success(list);
+};
+
+//상세 조회
+export const getAdminCoachingDetail = async (req, res, next) => {
+  try {
+    const { coachingId } = req.params;
+    const data = await getCoachingSessionDetail(coachingId);
+
+    if (!data) {
+      return next(new NotFoundError("지정한 코칭 기록을 찾을 수 없습니다."));
+    }
+
+    return res.success(data);
+  } catch (err) {
+    next(err);
+  }
+};
+

--- a/src/middlewares/adminOnly.middleware.js
+++ b/src/middlewares/adminOnly.middleware.js
@@ -1,0 +1,10 @@
+export const adminOnly = (req, res, next) => {
+  if (!req.isAdmin) {
+    return res.error({
+      status: 403,
+      errorCode: "ADMIN_ONLY",
+      reason: "관리자 전용 API입니다."
+    });
+  }
+  next();
+};

--- a/src/repositories/adminCoaching.repository.js
+++ b/src/repositories/adminCoaching.repository.js
@@ -1,0 +1,46 @@
+import { pool } from "../db.config.js";
+
+export const findAllCoachingSessions = async () => {
+  const query = `
+    SELECT 
+      cs.id,
+      cs.created_at,
+      u.nickname AS user_name,
+      jc.name AS job_category_name,
+      q.content AS question_title
+    FROM coaching_session cs
+    LEFT JOIN user u ON cs.user_id = u.id
+    LEFT JOIN job_category jc ON cs.job_category_id = jc.id
+    LEFT JOIN question q ON cs.question_id = q.id
+    ORDER BY cs.created_at DESC
+  `;
+
+  const [rows] = await pool.execute(query);
+  return rows;
+};
+
+// 상세 조회
+export const findCoachingSessionById = async (coachingId) => {
+  const query = `
+    SELECT 
+      cs.id,
+      cs.created_at,
+      cs.answer_text,
+      cs.ai_feedback,
+      cs.ai_model_answer,       
+      cs.job_category_id,          
+      u.nickname AS user_name,
+      u.email AS user_email,       
+      jc.name AS job_category_name,
+      q.content AS question_title
+    FROM coaching_session cs
+    LEFT JOIN user u ON cs.user_id = u.id
+    LEFT JOIN job_category jc ON cs.job_category_id = jc.id
+    LEFT JOIN question q ON cs.question_id = q.id
+    WHERE cs.id = ?
+  `;
+
+  const [rows] = await pool.execute(query, [coachingId]);
+  return rows[0];
+};
+

--- a/src/routers/admin.route.js
+++ b/src/routers/admin.route.js
@@ -1,9 +1,16 @@
 import express from "express";
 import { adminLoginController } from "../controllers/admin.controller.js";
+import { getAdminCoachingList } from "../controllers/adminCoaching.controller.js";
+import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
+import { setUserRole } from "../middlewares/role.middleware.js";
+import { adminOnly } from "../middlewares/adminOnly.middleware.js";
+import { getAdminCoachingDetail } from "../controllers/adminCoaching.controller.js";
 
 const router = express.Router();
 
-// °ü¸®ÀÚ ·Î±×ÀÎ
+// ê´€ë¦¬ì ë¡œê·¸ì¸
 router.post("/login", adminLoginController);
+router.get("/coaching", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminCoachingList)
+router.get("/coaching/:coachingId", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminCoachingDetail)
 
 export default router;

--- a/src/services/adminCoaching.service.js
+++ b/src/services/adminCoaching.service.js
@@ -1,0 +1,11 @@
+import { findAllCoachingSessions } from "../repositories/adminCoaching.repository.js";
+import { findCoachingSessionById } from "../repositories/adminCoaching.repository.js";
+
+
+export const getAllCoachingSessions = async () => {
+  return await findAllCoachingSessions();
+};
+
+export const getCoachingSessionDetail = async (coachingId) => {
+  return await findCoachingSessionById(coachingId);
+};


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->
[FEAT] 관리자 코칭 조회 기능 추가
---

## 📌 개요
- 관리자용 코칭 세션 전체 조회 API 구현
- 코칭 상세 조회 API 구현 (email, 직무, ai_model_answer 포함)
- 관리자 전용 접근 미들웨어(adminOnly) 추가
- 서비스/레포지토리 계층 구현
- 관리자 라우트 업데이트

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [x] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1.
2.

---

## 📎 관련 이슈
- Close #29 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

