### PR TITLE
[FEAT] 관리자 면접 후기 조회·수정·삭제 기능 구현

### DIFF
--- a/src/controllers/adminReview.controller.js
+++ b/src/controllers/adminReview.controller.js
@@ -1,0 +1,80 @@
+import { BadRequestError } from "../errors.js";
+import { NotFoundError } from "../errors.js";
+import { 
+    getAdminReviewList, getAdminReviewDetail ,
+    adminUpdateReview, adminDeleteReview
+} from "../services/adminReview.service.js";
+
+
+
+export const adminGetReviewList = async (req, res, next) => {
+  try {
+    const { jobCategoryId } = req.query;
+
+    if (jobCategoryId && isNaN(jobCategoryId)) {
+      return next(new BadRequestError("jobCategoryId는 숫자여야 합니다."));
+    }
+
+    const result = await getAdminReviewList(jobCategoryId);
+
+    return res.success(result);
+  } catch (err) {
+    next(err);
+  }
+};
+
+
+export const adminGetReviewDetail = async (req, res, next) => {
+  try {
+    const { reviewId } = req.params;
+
+    const data = await getAdminReviewDetail(reviewId);
+
+    if (!data) {
+      return next(new NotFoundError("지정한 면접 후기를 찾을 수 없습니다."));
+    }
+
+    return res.success(data);
+  } catch (err) {
+    next(err);
+  }
+};
+
+
+// 수정
+export const adminPatchReview = async (req, res, next) => {
+  try {
+    const { reviewId } = req.params;
+    const adminId = req.user.id; // 관리자는 JWT에서 가져옴
+
+    const updated = await adminUpdateReview(reviewId, adminId, req.body);
+
+    if (!updated) {
+      return next(new NotFoundError("수정하려는 면접 후기를 찾을 수 없습니다."));
+    }
+
+    return res.success(updated);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const adminDeleteReviewController = async (req, res, next) => {
+  try {
+    const { reviewId } = req.params;
+
+    const deleted = await adminDeleteReview(reviewId);
+
+    if (!deleted) {
+      return next(new NotFoundError("삭제하려는 면접 후기를 찾을 수 없습니다."));
+    }
+
+    return res.success({
+      message: "면접 후기가 정상적으로 삭제되었습니다.",
+      reviewId,
+    });
+
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/repositories/adminReview.repository.js
+++ b/src/repositories/adminReview.repository.js
@@ -1,0 +1,102 @@
+import { pool } from "../db.config.js";
+
+export const findAdminReviewList = async (jobCategoryId = null) => {
+  const baseQuery = `
+    SELECT 
+      r.id,
+      r.company_name,
+      r.content,
+      LEFT(r.content, 20) AS content_preview,   -- 내용 일부만
+      r.likes,
+      r.created_at,
+      u.nickname AS user_name,
+      jc.name AS job_category_name
+    FROM review r
+    LEFT JOIN user u ON r.user_id = u.id
+    LEFT JOIN job_category jc ON r.job_category_id = jc.id
+  `;
+
+  const order = ` ORDER BY r.created_at DESC`;
+
+  if (jobCategoryId) {
+    const [rows] = await pool.execute(
+      baseQuery + ` WHERE r.job_category_id = ? ` + order,
+      [jobCategoryId]
+    );
+    return rows;
+  }
+
+  const [rows] = await pool.execute(baseQuery + order);
+  return rows;
+};
+
+// 상세 조회
+export const findAdminReviewDetail = async (reviewId) => {
+  const query = `
+    SELECT 
+      r.id,
+      r.company_name,
+      r.content,
+      r.interview_tip,
+      r.likes,
+      r.created_at,
+      u.nickname AS user_name,
+      u.email AS user_email,
+      jc.name AS job_category_name
+    FROM review r
+    LEFT JOIN user u ON r.user_id = u.id
+    LEFT JOIN job_category jc ON r.job_category_id = jc.id
+    WHERE r.id = ?
+  `;
+
+  const [rows] = await pool.execute(query, [reviewId]);
+  return rows[0];
+};
+
+// 수정
+export const updateReviewByAdmin = async (reviewId, adminId, updateData) => {
+  const { company_name, job_category_id, content, interview_tip } = updateData;
+
+  const query = `
+    UPDATE review
+    SET 
+      company_name = ?,
+      job_category_id = ?,
+      content = ?,
+      interview_tip = ?,
+      edited_by_admin_id = ?
+    WHERE id = ?
+  `;
+
+  const params = [
+    company_name,
+    job_category_id,
+    content,
+    interview_tip,
+    adminId,
+    reviewId
+  ];
+
+  const [result] = await pool.execute(query, params);
+  return result;
+};
+
+// 리뷰 좋아요 먼저 삭제
+export const deleteReviewLikes = async (reviewId) => {
+  const query = `
+    DELETE FROM review_likes
+    WHERE review_id = ?
+  `;
+  await pool.execute(query, [reviewId]);
+};
+
+// 리뷰 삭제
+export const deleteReviewById = async (reviewId) => {
+  const query = `
+    DELETE FROM review
+    WHERE id = ?
+  `;
+
+  const [result] = await pool.execute(query, [reviewId]);
+  return result.affectedRows; // 삭제된 row 수 반환
+};

--- a/src/routers/admin.route.js
+++ b/src/routers/admin.route.js
@@ -1,16 +1,26 @@
 import express from "express";
-import { adminLoginController } from "../controllers/admin.controller.js";
-import { getAdminCoachingList } from "../controllers/adminCoaching.controller.js";
 import { verifyServiceAccessJWT } from "../middlewares/jwt.middleware.js";
 import { setUserRole } from "../middlewares/role.middleware.js";
 import { adminOnly } from "../middlewares/adminOnly.middleware.js";
-import { getAdminCoachingDetail } from "../controllers/adminCoaching.controller.js";
+import { adminLoginController } from "../controllers/admin.controller.js";
+import { getAdminCoachingList, getAdminCoachingDetail } from "../controllers/adminCoaching.controller.js";
+import { 
+    adminGetReviewList, adminGetReviewDetail,
+    adminPatchReview, adminDeleteReviewController
+ } from "../controllers/adminReview.controller.js";
+
 
 const router = express.Router();
 
-// 관리자 로그인
-router.post("/login", adminLoginController);
+
+router.post("/login", adminLoginController); // 관리자 로그인
 router.get("/coaching", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminCoachingList)
 router.get("/coaching/:coachingId", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminCoachingDetail)
+router.get("/reviews", verifyServiceAccessJWT, setUserRole, adminOnly, adminGetReviewList)
+router.get("/reviews/:reviewId", verifyServiceAccessJWT, setUserRole, adminOnly, adminGetReviewDetail)
+
+router.patch("/reviews/:reviewId", verifyServiceAccessJWT, setUserRole, adminOnly, adminPatchReview);
+
+router.delete("/reviews/:reviewId", verifyServiceAccessJWT, setUserRole, adminOnly, adminDeleteReviewController);
 
 export default router;

--- a/src/services/adminReview.service.js
+++ b/src/services/adminReview.service.js
@@ -1,0 +1,42 @@
+import { 
+    findAdminReviewList, findAdminReviewDetail,
+    updateReviewByAdmin,   
+    deleteReviewLikes, deleteReviewById, 
+ } 
+ from "../repositories/adminReview.repository.js";
+
+
+export const getAdminReviewList = async (jobCategoryId) => {
+  return await findAdminReviewList(jobCategoryId);
+};
+
+
+export const getAdminReviewDetail = async (reviewId) => {
+  return await findAdminReviewDetail(reviewId);
+};
+
+
+// 수정
+export const adminUpdateReview = async (reviewId, adminId, updateData) => {
+  // 기존 후기 존재하는지 확인
+  const existing = await findAdminReviewDetail(reviewId);
+  if (!existing) return null;
+
+  await updateReviewByAdmin(reviewId, adminId, updateData);
+  
+  // 업데이트 후 다시 조회해서 반환
+  return await findAdminReviewDetail(reviewId);
+};
+
+export const adminDeleteReview = async (reviewId) => {
+  // 존재하는지 확인
+  const exists = await findAdminReviewDetail(reviewId);
+  if (!exists) return null;
+
+  // 좋아요 먼저 삭제
+  await deleteReviewLikes(reviewId);
+
+  // 리뷰 삭제
+  const deleted = await deleteReviewById(reviewId);
+  return deleted > 0;
+};


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->
[FEAT] 관리자 면접 후기 조회·수정·삭제 기능 구현

---

## 📌 개요
- 관리자 페이지에서 면접 후기 데이터를 조회·편집·삭제할 수 있는 기능을 추가
-  관리자 면접 후기 리스트 조회 API 구현 (전체/직군별)
-  관리자 면접 후기 상세 조회 API 구현
- 관리자 면접 후기 수정 API 구현
- 관리자 면접 후기 삭제 API 구현 (likes → review 삭제 처리)

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1.
2.

---

## 📎 관련 이슈
- Close #30

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

