### PR TITLE
[FEAT] 질문 템플릿 관련 API 제작

### DIFF
--- a/src/controllers/adminQuestion.controller.js
+++ b/src/controllers/adminQuestion.controller.js
@@ -1,0 +1,101 @@
+import { NotFoundError } from "../errors.js";
+import { 
+    getQuestionList, getQuestionStats,
+    addQuestion, updateQuestion, removeQuestion,
+} from "../services/adminQuestion.service.js";
+import { getQuestionById } from "../repositories/adminQuestion.repository.js"; 
+
+export const getAdminQuestions = async (req, res, next) => {
+  try {
+    const { jobCategoryId } = req.query;
+
+    const list = await getQuestionList(jobCategoryId);
+    const stats = await getQuestionStats();
+
+    return res.success({
+      list,
+      stats
+    });
+  } catch (err) {
+    console.error(err);
+    return next(err);
+  }
+};
+
+export const createAdminQuestion = async (req, res, next) => {
+  try {
+    const { content, job_category_id, question_type } = req.body;
+
+    const insertId = await addQuestion({ 
+      content, 
+      job_category_id, 
+      question_type 
+    });
+
+    // 방금 생성된 질문 다시 조회해서 프론트로 반환
+    const createdQuestion = await getQuestionById(insertId);
+
+    return res.success({
+      message: "질문이 성공적으로 추가되었습니다.",
+      question: createdQuestion
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 질문 템플릿 수정 
+export const updateAdminQuestion = async (req, res, next) => {
+  try {
+    const { questionId } = req.params;
+    const { content, job_category_id, question_type } = req.body;
+
+    // 질문 존재 확인
+    const existing = await getQuestionById(questionId);
+    if (!existing) {
+      throw new NotFoundError("해당 질문을 찾을 수 없습니다.");
+    }
+
+    const updateFields = {
+      content: content ?? existing.content,
+      job_category_id: job_category_id ?? existing.job_category_id,
+      question_type: question_type ?? existing.question_type
+    };
+
+    await updateQuestion(questionId, updateFields);
+
+    // 수정 후 다시 조회
+    const updated = await getQuestionById(questionId);
+
+    return res.success({
+      message: "질문이 성공적으로 수정되었습니다.",
+      question: updated
+    });
+
+  } catch (err) {
+    next(err);
+  }
+};
+
+
+export const deleteAdminQuestion = async (req, res, next) => {
+  try {
+    const { questionId } = req.params;
+
+    // 존재 여부 확인
+    const existing = await getQuestionById(questionId);
+    if (!existing) {
+      throw new NotFoundError("해당 질문을 찾을 수 없습니다.");
+    }
+
+    await removeQuestion(questionId);
+
+    return res.success({
+      message: "질문이 성공적으로 삭제되었습니다.",
+      deleted_id: questionId
+    });
+
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/repositories/adminQuestion.repository.js
+++ b/src/repositories/adminQuestion.repository.js
@@ -1,0 +1,101 @@
+import { pool } from "../db.config.js";
+
+// 전체 또는 직군별 질문 목록 조회
+export const findQuestions = async (jobCategoryId) => {
+  let query = `
+    SELECT 
+      q.id,
+      q.question_type,
+      q.content,
+      jc.name AS job_category_name
+    FROM question q
+    LEFT JOIN job_category jc ON q.job_category_id = jc.id
+  `;
+
+  const params = [];
+
+  if (jobCategoryId) {
+    query += ` WHERE q.job_category_id = ? `;
+    params.push(jobCategoryId);
+  }
+
+  query += ` ORDER BY q.id ASC `;
+
+  const [rows] = await pool.execute(query, params);
+  return rows;
+};
+
+// 직군별 질문 통계
+export const findQuestionStats = async () => {
+  const query = `
+    SELECT 
+      jc.id AS job_category_id,
+      jc.name AS job_category_name,
+      COUNT(q.id) AS count
+    FROM job_category jc
+    LEFT JOIN question q ON q.job_category_id = jc.id
+    GROUP BY jc.id, jc.name
+    ORDER BY jc.id ASC
+  `;
+
+  const [rows] = await pool.execute(query);
+  return rows;
+};
+
+// 전체 질문 개수
+export const countAllQuestions = async () => {
+  const [rows] = await pool.execute(`
+    SELECT COUNT(*) AS total FROM question
+  `);
+  return rows[0].total;
+};
+
+// 질문 생성
+export const createQuestion = async ({ content, job_category_id, question_type }) => {
+  const query = `
+    INSERT INTO question 
+      (content, job_category_id, question_type, source_type)
+    VALUES (?, ?, ?, 'template')
+  `;
+
+  const [result] = await pool.execute(query, [
+    content,
+    job_category_id,
+    question_type
+  ]);
+
+  return result.insertId;
+};
+
+// 질문 단건 조회
+export const getQuestionById = async (id) => {
+  const query = `
+    SELECT 
+      q.id, q.content, q.job_category_id, q.question_type, q.source_type, q.created_at
+    FROM question q
+    WHERE q.id = ?
+  `;
+
+  const [rows] = await pool.execute(query, [id]);
+  return rows[0];
+};
+
+export const editQuestion = async (id, { content, job_category_id, question_type }) => {
+  const query = `UPDATE question SET content = ?, job_category_id = ?, question_type = ? WHERE id = ?`;
+
+  const [result] = await pool.execute(query, [
+    content,
+    job_category_id,
+    question_type,
+    id
+  ]);
+
+  return result;
+};
+
+export const deleteQuestionById = async (id) => {
+  const query = `DELETE FROM question WHERE id = ?`;
+
+  const [result] = await pool.execute(query, [id]);
+  return result;
+};

--- a/src/routers/admin.route.js
+++ b/src/routers/admin.route.js
@@ -8,19 +8,26 @@ import {
     adminGetReviewList, adminGetReviewDetail,
     adminPatchReview, adminDeleteReviewController
  } from "../controllers/adminReview.controller.js";
-
+import { getAdminQuestions, createAdminQuestion, updateAdminQuestion, deleteAdminQuestion } from "../controllers/adminQuestion.controller.js";
 
 const router = express.Router();
 
 
 router.post("/login", adminLoginController); // 관리자 로그인
+// 코칭 세션(히스토리)
 router.get("/coaching", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminCoachingList)
 router.get("/coaching/:coachingId", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminCoachingDetail)
+// 면접 후기 
 router.get("/reviews", verifyServiceAccessJWT, setUserRole, adminOnly, adminGetReviewList)
 router.get("/reviews/:reviewId", verifyServiceAccessJWT, setUserRole, adminOnly, adminGetReviewDetail)
-
 router.patch("/reviews/:reviewId", verifyServiceAccessJWT, setUserRole, adminOnly, adminPatchReview);
-
 router.delete("/reviews/:reviewId", verifyServiceAccessJWT, setUserRole, adminOnly, adminDeleteReviewController);
+// 질문 템플릿
+router.get("/question-templates", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminQuestions);
+router.post("/question-templates", verifyServiceAccessJWT, setUserRole, adminOnly, createAdminQuestion);
+router.patch("/question-templates/:questionId", verifyServiceAccessJWT, setUserRole, adminOnly, updateAdminQuestion);
+router.delete("/question-templates/:questionId", verifyServiceAccessJWT, setUserRole, adminOnly, deleteAdminQuestion);
+
+
 
 export default router;

--- a/src/services/adminQuestion.service.js
+++ b/src/services/adminQuestion.service.js
@@ -1,0 +1,50 @@
+import { 
+  findQuestions, findQuestionStats, countAllQuestions,
+  createQuestion, editQuestion, deleteQuestionById
+} from "../repositories/adminQuestion.repository.js";
+import { BadRequestError } from "../errors.js";
+
+export const getQuestionList = async (jobCategoryId) => {
+  return await findQuestions(jobCategoryId);
+};
+
+export const getQuestionStats = async () => {
+  const stats = await findQuestionStats();
+  const total = await countAllQuestions();
+
+  return {
+    total,
+    categories: stats
+  };
+};
+
+export const addQuestion = async ({ content, job_category_id, question_type }) => {
+
+  if (!content || !job_category_id) {
+    throw new BadRequestError("질문 내용과 직무는 필수입니다.");
+  }
+
+  return await createQuestion({
+    content,
+    job_category_id,
+    question_type
+  });
+};
+
+
+export const updateQuestion = async (id, { content, job_category_id, question_type }) => {
+
+  if (!content || !job_category_id) {
+    throw new BadRequestError("질문 내용과 직무는 필수입니다.");
+  }
+
+  return await editQuestion(id, {
+    content,
+    job_category_id,
+    question_type
+  });
+};
+
+export const removeQuestion = async (id) => {
+  return await deleteQuestionById(id);
+};


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->
[FEAT] 질문 템플릿 관련 API 제작
---

## 📌 개요
- 관리자 페이지에서 질문 템플릿을 조회·추가·수정·삭제할 수 있도록
- 전체 CRUD API를 구현
- 질문 템플릿 전체/직군별 조회 API 구현
- 질문 템플릿 생성 API 구현 (source_type 자동 template 처리)
- 질문 템플릿 수정 API 구현 (PATCH 기반 부분 수정 지원)
- 질문 템플릿 삭제 API 구현


## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1.
2.

---

## 📎 관련 이슈
- Close #33 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

