### PR TITLE
[Refactor] 관리자 기능 : 면접 후기 수정하기 개선

### DIFF
--- a/src/repositories/adminReview.repository.js
+++ b/src/repositories/adminReview.repository.js
@@ -36,6 +36,7 @@ export const findAdminReviewDetail = async (reviewId) => {
     SELECT 
       r.id,
       r.company_name,
+      r.job_category_id,
       r.content,
       r.interview_tip,
       r.likes,
@@ -54,8 +55,8 @@ export const findAdminReviewDetail = async (reviewId) => {
 };
 
 // 수정
-export const updateReviewByAdmin = async (reviewId, adminId, updateData) => {
-  const { company_name, job_category_id, content, interview_tip } = updateData;
+export const updateReviewByAdmin = async (reviewId, updateData) => {
+  const { company_name, job_category_id, content, interview_tip, edited_by_admin_id } = updateData;
 
   const query = `
     UPDATE review
@@ -63,7 +64,7 @@ export const updateReviewByAdmin = async (reviewId, adminId, updateData) => {
       company_name = ?,
       job_category_id = ?,
       content = ?,
-      interview_tip = ?,
+      interview_tip = ?, 
       edited_by_admin_id = ?
     WHERE id = ?
   `;
@@ -73,13 +74,13 @@ export const updateReviewByAdmin = async (reviewId, adminId, updateData) => {
     job_category_id,
     content,
     interview_tip,
-    adminId,
+    edited_by_admin_id, 
     reviewId
   ];
 
-  const [result] = await pool.execute(query, params);
-  return result;
+  return pool.execute(query, params);
 };
+
 
 // 리뷰 좋아요 먼저 삭제
 export const deleteReviewLikes = async (reviewId) => {

--- a/src/services/adminReview.service.js
+++ b/src/services/adminReview.service.js
@@ -18,15 +18,22 @@ export const getAdminReviewDetail = async (reviewId) => {
 
 // 수정
 export const adminUpdateReview = async (reviewId, adminId, updateData) => {
-  // 기존 후기 존재하는지 확인
   const existing = await findAdminReviewDetail(reviewId);
   if (!existing) return null;
 
-  await updateReviewByAdmin(reviewId, adminId, updateData);
-  
-  // 업데이트 후 다시 조회해서 반환
+  const updateFields = {
+    company_name: updateData.company_name ?? existing.company_name,
+    job_category_id: updateData.job_category_id ?? existing.job_category_id,
+    content: updateData.content ?? existing.content,
+    interview_tip: updateData.interview_tip ?? existing.interview_tip,
+    edited_by_admin_id: adminId
+  };
+
+  await updateReviewByAdmin(reviewId, updateFields);
+
   return await findAdminReviewDetail(reviewId);
 };
+
 
 export const adminDeleteReview = async (reviewId) => {
   // 존재하는지 확인


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->
[Refactor] 관리자 기능 : 면접 후기 수정하기 개선
---

## 📌 개요
- 관리자 면접 후기 수정 기능에서 PATCH 요청 시 일부 필드만 전달하면 undefined가 DB로 전달되어 SQL 오류가 발생하던 문제를 해결
- 기존 후기 데이터를 기반으로 수정 필드를 병합하여 부분 수정(PATCH) 동작을 안정적으로 지원하도록 개선
- 후기 상세 조회에서 누락된 job_category_id 컬럼을 SELECT에 포함하여 기존값 유지 로직이 정상 동작하도록 수정

## ✨ 작업 내용
- [ ] 기능 추가
- [x] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1.
2.

---

## 📎 관련 이슈
- Close #35

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

