### PR TITLE
[FEAT] 통계 페이지 관련 API 구현

### DIFF
--- a/src/controllers/adminStats.controller.js
+++ b/src/controllers/adminStats.controller.js
@@ -1,0 +1,14 @@
+import { fetchAdminStats } from "../services/adminStats.service.js";
+
+export const getAdminStatsController = async (req, res, next) => {
+  try {
+    const stats = await fetchAdminStats();
+    return res.success(stats);
+  } catch (err) {
+    next({
+      statusCode: 500,
+      errorCode: "FAILED_TO_GET_ADMIN_STATS",
+      reason: err.message
+    });
+  }
+};

--- a/src/repositories/adminStats.repository.js
+++ b/src/repositories/adminStats.repository.js
@@ -1,0 +1,117 @@
+import { pool } from "../db.config.js";
+
+export const getAdminStats = async () => {
+  // 인기 질문 TOP 5
+  const [popularQuestions] = await pool.query(`
+    SELECT 
+      q.id,
+      q.content,
+      COUNT(cs.id) AS used_count
+    FROM question q
+    LEFT JOIN coaching_session cs
+      ON q.id = cs.question_id
+    GROUP BY q.id
+    ORDER BY used_count DESC
+    LIMIT 5
+  `);
+
+  // 직무별 사용자 분포
+  const [jobCategoryDist] = await pool.query(`
+    SELECT 
+      jc.name AS category,
+      COUNT(u.id) AS user_count
+    FROM job_category jc
+    LEFT JOIN user u 
+      ON u.job_category_id = jc.id
+    GROUP BY jc.id
+  `);
+
+  // 이번달 / 지난달 코칭 수
+  const [[currentCoaching]] = await pool.query(`
+    SELECT COUNT(*) AS count
+    FROM coaching_session
+    WHERE DATE_FORMAT(created_at, '%Y-%m') = DATE_FORMAT(CURDATE(), '%Y-%m')
+  `);
+
+  const [[lastCoaching]] = await pool.query(`
+    SELECT COUNT(*) AS count
+    FROM coaching_session
+    WHERE DATE_FORMAT(created_at, '%Y-%m') = DATE_FORMAT(CURDATE() - INTERVAL 1 MONTH, '%Y-%m')
+  `);
+
+  // 증가 명수 계산 (+n / -n 형태)
+  const coachingDiff = currentCoaching.count - lastCoaching.count;
+  const coachingGrowth =
+    coachingDiff > 0 ? `+${coachingDiff}` : `${coachingDiff}`;
+
+  // 신규 사용자 수
+  const [[currentNewUsers]] = await pool.query(`
+    SELECT COUNT(*) AS count
+    FROM user
+    WHERE DATE_FORMAT(created_at, '%Y-%m') = DATE_FORMAT(CURDATE(), '%Y-%m')
+  `);
+
+  const [[lastNewUsers]] = await pool.query(`
+    SELECT COUNT(*) AS count
+    FROM user
+    WHERE DATE_FORMAT(created_at, '%Y-%m') = DATE_FORMAT(CURDATE() - INTERVAL 1 MONTH, '%Y-%m')
+  `);
+
+  const newUserDiff = currentNewUsers.count - lastNewUsers.count;
+  const newUserGrowth =
+    newUserDiff > 0 ? `+${newUserDiff}` : `${newUserDiff}`;
+
+    // 평균 답변 길이 (AI 피드백 + AI 모델 답변 길이 합)
+    const [[avgLength]] = await pool.query(`
+    SELECT 
+        AVG(
+        CHAR_LENGTH(ai_feedback) + 
+        CHAR_LENGTH(ai_model_answer)
+        ) AS avg_length
+    FROM coaching_session
+    WHERE ai_feedback IS NOT NULL 
+        AND ai_model_answer IS NOT NULL
+    `);
+
+
+  // 최근 6개월 월별 코칭 / 후기 수
+  const [monthlyCoaching] = await pool.query(`
+    SELECT 
+      DATE_FORMAT(created_at, '%Y-%m') AS month,
+      COUNT(*) AS count
+    FROM coaching_session
+    WHERE created_at >= DATE_FORMAT(CURDATE() - INTERVAL 5 MONTH, '%Y-%m-01')
+    GROUP BY month
+    ORDER BY month
+  `);
+
+  const [monthlyReviews] = await pool.query(`
+    SELECT 
+      DATE_FORMAT(created_at, '%Y-%m') AS month,
+      COUNT(*) AS count
+    FROM review
+    WHERE created_at >= DATE_FORMAT(CURDATE() - INTERVAL 5 MONTH, '%Y-%m-01')
+    GROUP BY month
+    ORDER BY month
+  `);
+
+  return {
+    popularQuestions,
+    jobCategoryDist,
+    coaching: {
+      thisMonth: currentCoaching.count,
+      lastMonth: lastCoaching.count,
+      growth: coachingGrowth   // "+n" / "-n"
+    },
+    newUsers: {
+      thisMonth: currentNewUsers.count,
+      lastMonth: lastNewUsers.count,
+      growth: newUserGrowth    // "+n" / "-n"
+    },
+    avgAnswerLength: avgLength.avg_length || 0,
+    monthlyTrend: {
+      coaching: monthlyCoaching,
+      reviews: monthlyReviews
+    }
+  };
+};

--- a/src/routers/admin.route.js
+++ b/src/routers/admin.route.js
@@ -10,6 +10,7 @@ import {
  } from "../controllers/adminReview.controller.js";
 import { getAdminQuestions, createAdminQuestion, updateAdminQuestion, deleteAdminQuestion } from "../controllers/adminQuestion.controller.js";
 import { getAdminUsers, getUsersDashboard } from "../controllers/adminUser.controller.js";
+import { getAdminStatsController } from "../controllers/adminStats.controller.js";
 
 const router = express.Router();
 
@@ -32,6 +33,8 @@ router.delete("/question-templates/:questionId", verifyServiceAccessJWT, setUser
 router.get("/users", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminUsers);
 router.get("/users/dashboard", verifyServiceAccessJWT, setUserRole, adminOnly, getUsersDashboard);
 
+// 통계 페이지
+router.get("/stats", verifyServiceAccessJWT, setUserRole, adminOnly, getAdminStatsController);
 
 
 

--- a/src/services/adminStats.service.js
+++ b/src/services/adminStats.service.js
@@ -1,0 +1,5 @@
+import { getAdminStats } from "../repositories/adminStats.repository.js";
+
+export const fetchAdminStats = async () => {
+  return await getAdminStats();
+};


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->
[FEAT] 관리자 대시보드 통계 API 개발
---

## 📌 개요
- 관리자 대시보드에서 필요한 통계 데이터를 제공하는 API를 개발
-  인기 질문 TOP 5 조회 기능 추가
- 직무별 사용자 분포 조회 기능 추가
- 이번달/지난달 코칭 수 및 증감 계산 기능 추가
- 신규 사용자 수 및 증감 계산 기능 추가
- 피드백 + 모델 답변 평균 길이 계산 기능 추가
-  최근 6개월 코칭/후기 월별 추이 조회 기능 추가

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1. /admin/stats 엔드포인트 호출
2. 응답에 아래 값이 정상 포함되는지 확인
popularQuestions
jobCategoryDist
coaching(thisMonth, lastMonth, growth)
newUsers(thisMonth, lastMonth, growth)
avgAnswerLength
monthlyTrend(coaching, reviews)
3. DB의 값 변경 후 통계가 정상 반영되는지 재확인

---

## 📎 관련 이슈
- Close #39 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

