### PR TITLE
[BUG] 사용자 직접 입력/AI 생성 질문의 히스토리 조회 오류 수정

### DIFF
--- a/src/repositories/history.repository.js
+++ b/src/repositories/history.repository.js
@@ -28,12 +28,16 @@ export const saveHistory = async (userId, coachingId) => {
 export const getUserHistoryList = async (userId) => {
   const sql = `
     SELECT
-      h.id AS history_id, h.coaching_id, h.created_at,
-      cs.job_category_id, q.content AS question_content,
-      cs.answer_text, cs.ai_feedback
+      h.id AS history_id,
+      h.coaching_id,
+      h.created_at,
+      cs.job_category_id,
+      COALESCE(q.content, cs.question_text) AS question_content,
+      cs.answer_text,
+      cs.ai_feedback
     FROM history h
     JOIN coaching_session cs ON h.coaching_id = cs.id
-    JOIN question q ON cs.question_id = q.id
+    LEFT JOIN question q ON cs.question_id = q.id
     WHERE h.user_id = ?
     ORDER BY h.created_at DESC;
   `;
@@ -46,12 +50,18 @@ export const getUserHistoryList = async (userId) => {
 export const getHistoryDetail = async (userId, historyId) => {
   const sql = `
     SELECT
-      h.id AS history_id, h.coaching_id, h.created_at,
-      cs.job_category_id, cs.question_id, q.content AS question_content,
-      cs.answer_text, cs.ai_feedback, cs.ai_model_answer
+      h.id AS history_id,
+      h.coaching_id,
+      h.created_at,
+      cs.job_category_id,
+      cs.question_id,
+      COALESCE(q.content, cs.question_text) AS question_content,
+      cs.answer_text,
+      cs.ai_feedback,
+      cs.ai_model_answer
     FROM history h
     JOIN coaching_session cs ON h.coaching_id = cs.id
-    JOIN question q ON cs.question_id = q.id
+    LEFT JOIN question q ON cs.question_id = q.id
     WHERE h.user_id = ? AND h.id = ?
     LIMIT 1;
   `;
@@ -59,6 +69,7 @@ export const getHistoryDetail = async (userId, historyId) => {
   const [rows] = await pool.query(sql, [userId, historyId]);
   return rows[0];
 };
+
 
 // 히스토리 단건 존재 여부 확인
 export const checkHistoryIdExists = async (historyId) => {


### PR DESCRIPTION
## 🔀 PR 제목
<!-- ex) [FEAT] 로그인 API 추가 -->

---

## 📌 개요
- question_id가 NULL인 코칭 세션 조회 시 히스토리 목록/상세에서 누락되는 문제 해결
- INNER JOIN → LEFT JOIN으로 변경
- COALESCE(q.content, cs.question_text) 적용하여 질문 텍스트 정상 출력

## ✨ 작업 내용
- [ ] 기능 추가
- [x] 오류 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

---

## 🔍 테스트 방법
1.
2.

---

## 📎 관련 이슈
- Close #42 

---

## ✔ 체크리스트
- [x] 코드 컨벤션 지켰는가?
- [x] 기존 기능이 깨지지 않는가?
- [x] 테스트를 수행했는가?
- [x] 리뷰어가 보기 편하게 PR을 나누었는가?

